### PR TITLE
Added an optional parameters with handshake headers and tls options for factory method

### DIFF
--- a/addons/gdstomp/core/STOMP.gd
+++ b/addons/gdstomp/core/STOMP.gd
@@ -4,5 +4,5 @@ extends RefCounted
 static func over_tcp() -> STOMPClient:
 	return STOMPClient.new(TcpSTOMPConnection.new())
 
-static func over_websockets() -> STOMPClient:
-	return STOMPClient.new(WebSTOMPConnection.new())
+static func over_websockets(handshake_headers: PackedStringArray = [], tls: TLSOptions = null) -> STOMPClient:
+	return STOMPClient.new(WebSTOMPConnection.new(handshake_headers, tls))

--- a/addons/gdstomp/core/STOMPClient.gd
+++ b/addons/gdstomp/core/STOMPClient.gd
@@ -1,7 +1,7 @@
 class_name STOMPClient
 extends RefCounted
 
-const body_separator: String = "\n\n"
+const BODY_SEPARATOR: String = "\n\n"
 
 signal received(packet: STOMPPacket)
 
@@ -89,7 +89,7 @@ func _invoke_listeners(packet: STOMPPacket) -> void:
 			callback.call(packet)
 
 func _unpack_message(message: String) -> STOMPPacket:
-	var content = message.split(body_separator)
+	var content = message.split(BODY_SEPARATOR)
 	var packed_headers = content[0].split("\n")
 	var command = packed_headers[0]
 	var headers = _unpack_headers(packed_headers)
@@ -105,7 +105,7 @@ func _unpack_headers(headers: PackedStringArray) -> Dictionary:
 	return unpacked_headers
 
 func _pack_message(command: String, headers: Dictionary, body: String) -> PackedByteArray:
-	var message: String = command + "\n" + _pack_headers(headers) + body_separator + body
+	var message: String = command + "\n" + _pack_headers(headers) + BODY_SEPARATOR + body
 	var raw_bytes: PackedByteArray = message.to_utf8_buffer()
 	raw_bytes.append(0)
 	return raw_bytes

--- a/addons/gdstomp/core/connections/WebSTOMPConnection.gd
+++ b/addons/gdstomp/core/connections/WebSTOMPConnection.gd
@@ -8,14 +8,16 @@ signal start_closing()
 signal closed()
 
 var state: int = -1
-var peer: WebSocketPeer = WebSocketPeer.new()
+var peer: WebSocketPeer
 var tls: TLSOptions
 
-func _init(tls: TLSOptions = null) -> void:
+func _init(handshake_headers: PackedStringArray = [], tls: TLSOptions = null) -> void:
+	self.peer = WebSocketPeer.new()
+	self.peer.handshake_headers = handshake_headers
 	self.tls = tls
 
 func connect_to_host(url: String) -> int:
-	return peer.connect_to_url(url)
+	return peer.connect_to_url(url, tls)
 
 func close(code: int = 1000, reason: String = "") -> void:
 	peer.close(code, reason)


### PR DESCRIPTION
Added an optional parameter with handshake headers and tls options for factory method of client creation.

Usage example:

```gdscript
var handshake_headers: PackedStringArray = ["header-1", "header-2"]
var tls_options: TLSOptions = TLSOptions.client_unsafe()
var stomp_client: STOMPClient = STOMP.over_websockets(handshake_headers, tls_options)
```

Close #1 